### PR TITLE
docs: update express

### DIFF
--- a/pages/guides/nodejs/express.en-US.mdx
+++ b/pages/guides/nodejs/express.en-US.mdx
@@ -17,7 +17,6 @@ Deploy your Express App in Zeabur with one click.
 
 ```bash
 # Use express-generator
-npm install -g express-generator
 npx express-generator
 ```
 

--- a/pages/guides/nodejs/express.zh-CN.mdx
+++ b/pages/guides/nodejs/express.zh-CN.mdx
@@ -17,7 +17,6 @@ ogImageSubtitle: 在 Zeabur 部署你的 Express 应用
 
 ```bash
 # 使用 express-generator
-npm install -g express-generator
 npx express-generator
 ```
 

--- a/pages/guides/nodejs/express.zh-TW.mdx
+++ b/pages/guides/nodejs/express.zh-TW.mdx
@@ -17,7 +17,6 @@ ogImageSubtitle: 在 Zeabur 部署你的 Express 應用
 
 ```bash
 # 使用 express-generator
-npm install -g express-generator
 npx express-generator
 ```
 


### PR DESCRIPTION
修正了文档中的错误。

`npm install -g` 之后，`express-generator` 直接就在 PATH 下，可以直接运行 `express-generator` 进行 express 项目创建。

`npx express-genetor` 则是先下载再执行，无需将 `express-generator` 全局安装。

因此这两个命令选一个就行，但是这里两个全都加上了，也没有其他提示，感觉会误导人。

express 那边现在推荐使用 `npx`，所以我删掉了 `npm install -g` 这个方式。